### PR TITLE
Refactor command classes to reduce code duplication

### DIFF
--- a/src/main/java/MainWindow.java
+++ b/src/main/java/MainWindow.java
@@ -25,6 +25,9 @@ public class MainWindow extends AnchorPane {
     private Image userImage = new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
     private Image mullerImage = new Image(this.getClass().getResourceAsStream("/images/DaMuller.png"));
 
+    /**
+     * Starts of the program with greetings and a GUI.
+     */
     @FXML
     public void initialize() {
         String welcomeMessage = "Hello! I'm Muller!\nWhat can I do for you?";

--- a/src/main/java/muller/Muller.java
+++ b/src/main/java/muller/Muller.java
@@ -37,7 +37,6 @@ public class Muller {
         // Programmer-level assumption: input should not be null or empty
         assert input != null : "Input should not be null";
         assert !input.trim().isEmpty() : "Input should not be empty";
-        
         Parser parser = new Parser();
         try {
             Command command = parser.parse(input);

--- a/src/main/java/muller/command/AddCommand.java
+++ b/src/main/java/muller/command/AddCommand.java
@@ -27,8 +27,8 @@ public class AddCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MullerException {
-        super.assertionTest(tasks, ui, storage);
-        if (commandInputs.length < 2) {
+        CommandUtil.assertionTest(tasks, ui, storage);
+        if (CommandUtil.isInputComplete(commandInputs)) {
             throw new MullerException(taskType.equals("T") ? "Todo what?"
                     : taskType.equals("D") ? "Deadline for what?" : "Event for what?");
         }
@@ -65,7 +65,7 @@ public class AddCommand extends Command {
      */
     private Task parseDeadline(String details) throws MullerException {
         String[] detailParts = details.split("/by", 2);
-        if (detailParts.length < 2) {
+        if (CommandUtil.isInputComplete(detailParts)) {
             throw new MullerException("Oops, you didn't specify the deadline!");
         }
         Task task = new Task(detailParts[0].trim());
@@ -83,12 +83,12 @@ public class AddCommand extends Command {
      * @throws MullerException If the date format is invalid.
      */
     private Task parseEvent(String details) throws MullerException {
-        String[] detailParts = details.split("/from", 2);
-        if (detailParts.length < 2) {
+        String[] detailParts = details.split("/from", 2); //A String array that separates event name and relevant dates.
+        if (CommandUtil.isInputComplete(detailParts)) { //Checks if dates are specified.
             throw new MullerException("Oops, you didn't specify the start date!");
         }
-        String[] dateParts = detailParts[1].split("/to", 2);
-        if (dateParts.length < 2) {
+        String[] dateParts = detailParts[1].split("/to", 2); // A String array that separates start date and end date.
+        if (CommandUtil.isInputComplete(dateParts)) { //Checks if end date/start date is specified.
             throw new MullerException("You missed out either the start or end date!");
         }
         Task task = new Task(detailParts[0].trim());

--- a/src/main/java/muller/command/Command.java
+++ b/src/main/java/muller/command/Command.java
@@ -17,19 +17,6 @@ public abstract class Command {
      * @throws MullerException If an error occurs during command execution.
      */
     public abstract String execute(TaskList tasks, Ui ui, Storage storage) throws MullerException;
-
-    /**
-     * Checks if the input task, ui, storage are not null.
-     *
-     * @param tasks
-     * @param ui
-     * @param storage
-     */
-    public void assertionTest(TaskList tasks, Ui ui, Storage storage) {
-        assert tasks != null : "TaskList should not be null";
-        assert ui != null : "Ui should not be null";
-        assert storage != null : "Storage should not be null";
-    }
 }
 
 

--- a/src/main/java/muller/command/CommandUtil.java
+++ b/src/main/java/muller/command/CommandUtil.java
@@ -1,0 +1,89 @@
+package muller.command;
+
+import muller.storage.Storage;
+import muller.task.TaskList;
+import muller.ui.Ui;
+
+/**
+ * Utility class for common validation methods.
+ */
+public class CommandUtil {
+    /**
+     * Checks if the input task, ui, storage are not null.
+     *
+     * @param tasks
+     * @param ui
+     * @param storage
+     */
+    public static void assertionTest(TaskList tasks, Ui ui, Storage storage) {
+        assert tasks != null : "TaskList should not be null";
+        assert ui != null : "Ui should not be null";
+        assert storage != null : "Storage should not be null";
+    }
+
+    /**
+     * Checks if the input task index is valid.
+     *
+     * @param index
+     * @param taskListSize
+     * @return
+     */
+    public static boolean isValidTaskIndex(int index, int taskListSize) {
+        return index >= 0 && index < taskListSize;
+    }
+
+    /**
+     * Check if the input is complete for different tasks.
+     *
+     * @param commandInputs
+     * @return
+     */
+    public static boolean isInputComplete(String[] commandInputs) {
+        return commandInputs.length < 2;
+    }
+
+    /**
+     * Checks if the input string is a numeric value.
+     *
+     * @param str The input string.
+     * @return True if the string is numeric, false otherwise.
+     */
+    public static boolean isNumeric(String str) {
+        try {
+            Integer.parseInt(str);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check the command to delete tasks is complete
+     *
+     * @param commandInputs
+     * @return
+     */
+    public static boolean isDeleteCommandValid(String[] commandInputs) {
+        return commandInputs.length < 2 || !isNumeric(commandInputs[1]);
+    }
+
+    /**
+     * Check if the input is complete for different tasks.
+     *
+     * @param commandInputs
+     * @return
+     */
+    public static boolean isFindCommandValid(String[] commandInputs) {
+        return commandInputs.length < 2 || commandInputs[1].trim().isEmpty();
+    }
+
+    /**
+     * Check the command to delete tasks is complete
+     *
+     * @param commandInputs
+     * @return
+     */
+    public static boolean isMarkCommandValid(String[] commandInputs) {
+        return commandInputs.length < 2 || !isNumeric(commandInputs[1]);
+    }
+}

--- a/src/main/java/muller/command/DeleteCommand.java
+++ b/src/main/java/muller/command/DeleteCommand.java
@@ -1,6 +1,5 @@
 package muller.command;
 
-import muller.Muller;
 import muller.storage.Storage;
 import muller.task.Task;
 import muller.task.TaskList;
@@ -19,17 +18,19 @@ public class DeleteCommand extends Command {
      * @throws MullerException If the input is not a valid task number.
      */
     public DeleteCommand(String[] inputs) throws MullerException {
-        if (inputs.length < 2 || !isNumeric(inputs[1])) {
+        if (CommandUtil.isDeleteCommandValid(inputs)) {
             throw new MullerException("Pick a valid task number to delete!");
         }
+
+        //Resize the index to make sure align with 0-indexed list.
         this.index = Integer.parseInt(inputs[1]) - 1;
     }
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MullerException {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         try {
-            if (index < 0 || index >= tasks.getSize()) {
+            if (CommandUtil.isValidTaskIndex(index, tasks.getSize())) {
                 throw new MullerException("Invalid task number!");
             }
             Task deletedTask = tasks.get(index);
@@ -38,21 +39,6 @@ public class DeleteCommand extends Command {
             return ui.showTaskDeleted(tasks, deletedTask, index);
         } catch (MullerException e) {
             return e.getMessage();
-        }
-    }
-
-    /**
-     * Checks if the input string is a numeric value.
-     *
-     * @param str The input string.
-     * @return True if the string is numeric, false otherwise.
-     */
-    private boolean isNumeric(String str) {
-        try {
-            Integer.parseInt(str);
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
         }
     }
 }

--- a/src/main/java/muller/command/ExitCommand.java
+++ b/src/main/java/muller/command/ExitCommand.java
@@ -10,7 +10,7 @@ import muller.ui.Ui;
 public class ExitCommand extends Command {
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         return "Bye. Hope to see you again soon!";
     }
 }

--- a/src/main/java/muller/command/FindCommand.java
+++ b/src/main/java/muller/command/FindCommand.java
@@ -20,7 +20,7 @@ public class FindCommand extends Command {
      * @throws MullerException If the keyword is missing.
      */
     public FindCommand(String[] inputs) throws MullerException {
-        if (inputs.length < 2 || inputs[1].trim().isEmpty()) {
+        if (CommandUtil.isFindCommandValid(inputs)) {
             throw new MullerException("Please provide a keyword to search for!");
         }
         this.keyword = inputs[1].trim();
@@ -28,7 +28,7 @@ public class FindCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         List<Task> matchingTasks = tasks.findTasksByKeyword(keyword);
         return ui.showMatchingTasks(matchingTasks);
     }

--- a/src/main/java/muller/command/ListCommand.java
+++ b/src/main/java/muller/command/ListCommand.java
@@ -10,7 +10,7 @@ import muller.ui.Ui;
 public class ListCommand extends Command {
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         return ui.showTaskList(tasks);
     }
 }

--- a/src/main/java/muller/command/MarkCommand.java
+++ b/src/main/java/muller/command/MarkCommand.java
@@ -17,7 +17,7 @@ public class MarkCommand extends Command {
      * @throws MullerException If the input is not a valid task number.
      */
     public MarkCommand(String[] inputs) throws MullerException {
-        if (inputs.length < 2 || !isNumeric(inputs[1])) {
+        if (CommandUtil.isMarkCommandValid(inputs)) {
             throw new MullerException("Pick a valid task number to mark!");
         }
         this.index = Integer.parseInt(inputs[1]) - 1;
@@ -25,7 +25,7 @@ public class MarkCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MullerException {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         tasks.get(index).markAsDone();
         storage.saveTasks(tasks);
         return ui.showTaskMarked(tasks, index);

--- a/src/main/java/muller/command/OnCommand.java
+++ b/src/main/java/muller/command/OnCommand.java
@@ -22,7 +22,7 @@ public class OnCommand extends Command {
      * @throws MullerException If the input date format is invalid.
      */
     public OnCommand(String[] inputs) throws MullerException {
-        if (inputs.length < 2) {
+        if (CommandUtil.isInputComplete(inputs)) {
             throw new MullerException("Specify a date (e.g., 'on 2019-10-15')!");
         }
         try {
@@ -34,7 +34,7 @@ public class OnCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         return ui.showTaskOnDate(tasks, date);
     }
 }

--- a/src/main/java/muller/command/UnmarkCommand.java
+++ b/src/main/java/muller/command/UnmarkCommand.java
@@ -17,7 +17,7 @@ public class UnmarkCommand extends Command {
      * @throws MullerException If the input is not a valid task number.
      */
     public UnmarkCommand(String[] inputs) throws MullerException {
-        if (inputs.length < 2 || !isNumeric(inputs[1])) {
+        if (CommandUtil.isMarkCommandValid(inputs)) {
             throw new MullerException("Pick a valid task number to unmark!");
         }
         this.index = Integer.parseInt(inputs[1]) - 1;
@@ -25,7 +25,7 @@ public class UnmarkCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws MullerException {
-        super.assertionTest(tasks, ui, storage);
+        CommandUtil.assertionTest(tasks, ui, storage);
         tasks.get(index).markAsNotDone();
         storage.saveTasks(tasks);
         return ui.showTaskUnMarked(tasks, index);

--- a/src/main/java/muller/ui/Ui.java
+++ b/src/main/java/muller/ui/Ui.java
@@ -2,7 +2,6 @@ package muller.ui;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Scanner;
 
 import muller.command.MullerException;
 import muller.task.Task;
@@ -54,7 +53,7 @@ public class Ui {
         try {
             return ("Nice! I've marked this task as done:\n"
                     + "  " + tasks.get(index));
-        } catch (MullerException e){
+        } catch (MullerException e) {
             return e.getMessage();
         }
     }
@@ -69,7 +68,7 @@ public class Ui {
         try {
             return ("OK, I've marked this task as not done yet:\n"
                     + "  " + tasks.get(index));
-        } catch (MullerException e){
+        } catch (MullerException e) {
             return e.getMessage();
         }
     }


### PR DESCRIPTION
The DeleteCommand, MarkCommand, and UnmarkCommand classes have duplicate code for validating task indices and checking numeric input.

Duplicated validation logic can introduce inconsistencies and makes maintaining the codebase harder, as changes to validation logic need to be repeated across multiple files.

This commit extracts the common validation logic into a utility class CommandUtils to:

    Centralize index and numeric validation
    Improve code maintainability
    Reduce duplication

By doing this, we ensure the validation logic is consistent across all relevant commands, making future changes easier to implement and reducing the risk of bugs.