### PR TITLE
Enable the chatbot to give reminders about tasks

### DIFF
--- a/src/main/java/muller/command/RemindCommand.java
+++ b/src/main/java/muller/command/RemindCommand.java
@@ -1,4 +1,52 @@
 package muller.command;
 
-public class RemindCommand {
+import java.time.LocalDate;
+import java.util.List;
+
+import muller.storage.Storage;
+import muller.task.Task;
+import muller.task.TaskList;
+import muller.ui.Ui;
+
+/**
+ * Command to remind users about upcoming deadlines and events.
+ */
+public class RemindCommand extends Command {
+    private int daysBeforeReminder;
+
+    /**
+     * Constructs a RemindCommand with the specified inputs.
+     *
+     * @param inputs The command inputs.
+     * @throws MullerException If the input date format is invalid.
+     */
+    public RemindCommand(String[] inputs) throws MullerException {
+        if (CommandUtil.isRemindCommandNotValid(inputs)) {
+            throw new MullerException("Specify the number of days before reminder!");
+        }
+        try {
+            daysBeforeReminder = Integer.parseInt(inputs[1].trim());
+        } catch (Exception e) {
+            throw new MullerException("Invalid format. Use 'remind [number of days before reminder]'.");
+        }
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) {
+        LocalDate today = LocalDate.now();
+        LocalDate upcoming = today.plusDays(daysBeforeReminder);
+
+        List<Task> reminders = tasks.getTasksDueSoon(today, upcoming);
+        if (reminders.isEmpty()) {
+            return "No upcoming tasks in the next " + daysBeforeReminder + " days.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Here are the tasks due in the next " + daysBeforeReminder + " days:\n");
+        for (int i = 0; i < reminders.size(); i++) {
+            sb.append((i + 1) + ": " + reminders.get(i) + "\n");
+        }
+        return sb.toString();
+    }
 }
+


### PR DESCRIPTION
What is the current situation?

The current system does not provide users with reminders for tasks that have upcoming deadlines or events. Users may miss important deadlines because there is no way to filter or notify them about these time-sensitive tasks.
Why does it need to change?

Implementing a RemindCommand will enhance user experience by proactively informing them about tasks that need attention soon. This feature is particularly useful for managing deadlines and staying organized. By adding this command, the system can:

- 🔔 Provide reminders about deadlines and events that are due soon.
- 🔍 Offer a quick way to see tasks that are approaching their deadlines.
- 🗓️ Allow users to customize how many days in advance they want to be reminded.

What is being done?

This pull request introduces a new RemindCommand to display tasks that are due within a specified number of days from the current date.

1.    User Input:
- Accepts the command in the format: remind [number of days before reminder].

2.    Customizable Days Before Reminder:
- Allows the user to specify how many days in advance they want to be notified.

3.    Display Upcoming Tasks:
- Formats and displays a list of tasks due in the next few days.

Checklist:

- [X] Implement RemindCommand to display upcoming deadlines.
- [X] Modify TaskList to support filtering by date range.
- [X] Add UI support for displaying reminders.
- [X] Add unit tests for various reminder scenarios.